### PR TITLE
Update composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         }
     },
     "require": {
-        "symfony/console": "~4.0",
-        "symfony/process": "~4.0",
+        "symfony/console": "~5.0",
+        "symfony/process": "~5.0",
         "guzzlehttp/guzzle": "~6.0"
     },
     "bin": [

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -45,5 +45,7 @@ class NewCommand extends Command
         foreach ($installers as $installer) {
             (new $installer($this, $input->getArgument('name'), $input->getArgument('version')))->install();
         }
+
+        return 0;
     }
 }

--- a/src/RegisterCommand.php
+++ b/src/RegisterCommand.php
@@ -47,6 +47,8 @@ class RegisterCommand extends Command
         $this->storeToken($input->getArgument('token'));
 
         $this->tokenIsValid($output);
+
+        return 0;
     }
 
     /**

--- a/src/TokenCommand.php
+++ b/src/TokenCommand.php
@@ -32,5 +32,7 @@ class TokenCommand extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('<info>FusionCMS Registration Token:</info> '.$this->readToken());
+
+        return 0;
     }
 }


### PR DESCRIPTION
Update Symfony versions in composer file. Add bogus return statement to `execute()` commands to work with Symfony 5.x